### PR TITLE
Fixed klaussilveira/gitlist#140

### DIFF
--- a/lib/Gitter/Model/Commit/Commit.php
+++ b/lib/Gitter/Model/Commit/Commit.php
@@ -12,6 +12,7 @@
 namespace Gitter\Model\Commit;
 
 use Gitter\Model\AbstractModel;
+use Gitter\Util\DateTime;
 
 class Commit extends AbstractModel
 {
@@ -38,7 +39,7 @@ class Commit extends AbstractModel
         );
 
         $this->setDate(
-            new \DateTime('@' . $data['date'])
+            new DateTime('@' . $data['date'])
         );
 
         $this->setCommiter(
@@ -46,7 +47,7 @@ class Commit extends AbstractModel
         );
 
         $this->setCommiterDate(
-            new \DateTime('@' . $data['commiter_date'])
+            new DateTime('@' . $data['commiter_date'])
         );
 
         $this->setMessage($data['message']);

--- a/lib/Gitter/Util/DateTime.php
+++ b/lib/Gitter/Util/DateTime.php
@@ -1,0 +1,63 @@
+<?php
+// lib/Gitter/Util/DateTime.php
+
+/*
+ * This file is part of the Gitter library.
+ *
+ * (c) Klaus Silveira <klaussilveira@php.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitter\Util;
+
+/**
+ * Fixes the issue that the $timezone parameter and the current timezone are ignored when
+ * the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone
+ * (e.g. 2010-01-28T15:00:00+02:00).
+ *
+ * @link https://github.com/klaussilveira/gitlist/issues/140
+ */
+class DateTime extends \DateTime
+{
+    /**
+     * @const The regular expression for an UNIX timestamp
+     */
+    const UNIX_TIMESTAMP_PATTERN = '/^@\d+$/';
+
+    /**
+     * @param string       $time     A date/time string.
+     * @param DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
+     *
+     * @return DateTime A new DateTime instance.
+     *
+     * @link http://php.net/manual/en/datetime.construct.php
+     */
+    public function __construct($time = 'now', DateTimeZone $timezone = null)
+    {
+        parent::__construct($time, $timezone);
+
+        if ($this->isUnixTimestamp($time)) {
+            if (!$timezone)
+                $timezone = new \DateTimeZone(date_default_timezone_get());
+
+            $this->setTimezone($timezone);
+        }
+    }
+
+    /**
+     * Checks if an UNIX timestamp is passed.
+     *
+     * @param string $time A date/time string.
+     *
+     * @return bool true if the $time parameter is an UNIX timestamp, unless false
+     */
+    protected function isUnixTimestamp($time)
+    {
+        if (preg_match(self::UNIX_TIMESTAMP_PATTERN, $time))
+            return true;
+
+        return false;
+    }
+}


### PR DESCRIPTION
Added extended DateTime object that sets the correct timezone while passing a UNIX timestamp. The commit model uses the new DateTime object now.
