### PR TITLE
Inheritance DateTime Correction

### DIFF
--- a/lib/Gitter/Util/DateTime.php
+++ b/lib/Gitter/Util/DateTime.php
@@ -36,7 +36,12 @@ class DateTime extends \DateTime
      */
     public function __construct($time = 'now', DateTimeZone $timezone = null)
     {
-        parent::__construct($time, $timezone);
+        if ($timezone) {
+            parent::__construct($time, $timezone);
+        }
+        else {
+            parent::__construct($time);
+        }
 
         if ($this->isUnixTimestamp($time)) {
             if (!$timezone)


### PR DESCRIPTION
Avoid php error : "DateTime::__construct() expects parameter 2 to be DateTimeZone, null given"
