### PR TITLE
Fixes fatal error when a commit has 0 updated files

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -384,7 +384,8 @@ class Repository
                 $lineNumOld++;
                 $lineNumNew++;
             }
-
+            
+            if($diff)
             $diff->addLine($log, $lineNumOld, $lineNumNew);
         }
 


### PR DESCRIPTION
Fixes "Fatal error: Call to a member function addLine() on a non-object" when commit has 0 updated files
