### PR TITLE
Make "no description" really mean "no description"

### DIFF
--- a/lib/Gitter/Client.php
+++ b/lib/Gitter/Client.php
@@ -315,7 +315,7 @@ class Client
             if (file_exists($description)) {
                 $description = file_get_contents($description);
             } else {
-                $description = 'There is no repository description file. Please, create one to remove this message.';
+                $description = null;
             }
 
 


### PR DESCRIPTION
Gitter is a library for accessing git repositories from PHP.
It's meant to be used by other (higher-level) tools to provide
that functionality.

Having Gitter talk to the user by means of fake description messages
seems wrong.

This makes not having a description file for a repository
cause the description to be NULL.
Some higher-level tool that uses this library can then detect this
NULL value and decide how to report it to the user.
