### PR TITLE
Ignore repositories that are not yet initialized (no commits) 

### DIFF
--- a/lib/Gitter/Client.php
+++ b/lib/Gitter/Client.php
@@ -297,8 +297,8 @@ class Client
             return;
         }
 
-        $isBare = file_exists($path . '/HEAD');
-        $isRepository = file_exists($path . '/.git/HEAD');
+        $isBare = count(glob($path . '/refs/heads/*')) !== 0;
+        $isRepository = count(glob($path . '/.git/refs/heads/*')) !== 0;
 
         if ($isRepository || $isBare) {
             $tmp = array_reverse(explode(DIRECTORY_SEPARATOR, rtrim($path, DIRECTORY_SEPARATOR)));


### PR DESCRIPTION
This patch makes a repository with no commit ignored (considered as not a git repo).

This is a quick fix preventing newly-created repos to make the whole list fail in gitlist (even if there is other repos):

<ref>
Oops! An exception has been thrown during the rendering of a template ("Parameter "branch" for route "rss" must match "(?!/|._([/.].|//|@{|\))[^\040\177 ~^:?_[]+(?<!.lock|[/.])" ("" given) to generate a corresponding URL.") in "index.twig" at line 13. 
</ref>

A more suitable fix would be to display something specific for empty repos.
