### PR TITLE
Add the ability to restrict the number of log entries returned

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -281,10 +281,21 @@ class Repository
     /**
      * Show the repository commit log
      *
+     * @param string $file The filename of a specific file to show commits for, or null to show all commits from all files
+     * @param int $num Restrict the commits to the specified number. Set it to -1 (default) to show all commits
+     * @param int $skip Skip the specified number of commits before including $num commits
      * @return array Commit log
      */
-    public function getCommits($file = null)
+    public function getCommits($file = null, $num = -1, $skip = 0)
     {
+        $extra = "";
+        if ($num > 0) {
+            $extra = " --max-count=$num ";
+        }
+        if ($skip > 0) {
+            $extra = "$extra --skip=$skip ";
+        }
+        
         $command = "log --pretty=format:\"<item><hash>%H</hash><short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents><author>%an</author><author_email>%ae</author_email><date>%at</date><commiter>%cn</commiter><commiter_email>%ce</commiter_email><commiter_date>%ct</commiter_date><message><![CDATA[%s]]></message></item>\"";
 
         if ($file) {

--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -295,8 +295,8 @@ class Repository
         if ($skip > 0) {
             $extra = "$extra --skip=$skip ";
         }
-        
-        $command = "log --pretty=format:\"<item><hash>%H</hash><short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents><author>%an</author><author_email>%ae</author_email><date>%at</date><commiter>%cn</commiter><commiter_email>%ce</commiter_email><commiter_date>%ct</commiter_date><message><![CDATA[%s]]></message></item>\"";
+
+        $command = "log $extra --pretty=format:\"<item><hash>%H</hash><short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents><author>%an</author><author_email>%ae</author_email><date>%at</date><commiter>%cn</commiter><commiter_email>%ce</commiter_email><commiter_date>%ct</commiter_date><message><![CDATA[%s]]></message></item>\"";
 
         if ($file) {
             $command .= " $file";

--- a/tests/Gitter/Tests/RepositoryTest.php
+++ b/tests/Gitter/Tests/RepositoryTest.php
@@ -436,6 +436,34 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testIsGettingCommitWithSpecifiedNumber()
+    {
+        $repository = $this->client->getRepository(self::$tmpdir . '/testrepo');
+        $commits = $repository->getCommits(null, 2);
+        $all_commits = $repository->getCommits();
+
+        $this->assertCount(2, $commits);
+        $this->assertGreaterThan(2, count($all_commits));
+    }
+
+    public function testIsGettingCommitWithSkip()
+    {
+        $repository = $this->client->getRepository(self::$tmpdir . '/testrepo');
+
+        $last_two_commits = $repository->getCommits(null, 2);
+        $last_two_commits_again = $repository->getCommits(null, 2, 0);
+
+        $first_two_commits = $repository->getCommits(null, 2, 2);
+
+        $this->assertEquals($last_two_commits[0], $last_two_commits_again[0]);
+        $this->assertEquals($last_two_commits[1], $last_two_commits_again[1]);
+
+        $this->assertNotEquals($last_two_commits[0], $first_two_commits[0]);
+        $this->assertNotEquals($last_two_commits[1], $first_two_commits[1]);
+        $this->assertNotEquals($last_two_commits[0], $first_two_commits[1]);
+        $this->assertNotEquals($last_two_commits[1], $first_two_commits[0]);
+    }
+
     public function testIsGettingCurrentHead()
     {
         $repository = $this->client->getRepository(self::$tmpdir . '/testrepo');


### PR DESCRIPTION
This is critical for interacting with repositories with thousands of commits that need to be paginated between. I have tried not to break the existing API, so all commits will still be returned by default and $file is still the first parameter
