### PR TITLE
Git 1.8.4 supports ignoring whitespace in diffs

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -310,7 +310,11 @@ class Repository
      */
     public function getCommit($commitHash)
     {
-        $logs = $this->getClient()->run($this, "show --pretty=format:\"<item><hash>%H</hash><short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents><author>%an</author><author_email>%ae</author_email><date>%at</date><commiter>%cn</commiter><commiter_email>%ce</commiter_email><commiter_date>%ct</commiter_date><message><![CDATA[%s]]></message><body><![CDATA[%b]]></body></item>\" $commitHash");
+        if (version_compare($this->getClient()->getVersion(), '1.8.4', '>=')) {
+            $logs = $this->getClient()->run($this, "show --ignore-blank-lines -w -b --pretty=format:\"<item><hash>%H</hash><short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents><author>%an</author><author_email>%ae</author_email><date>%at</date><commiter>%cn</commiter><commiter_email>%ce</commiter_email><commiter_date>%ct</commiter_date><message><![CDATA[%s]]></message><body><![CDATA[%b]]></body></item>\" $commitHash");
+        } else {
+            $logs = $this->getClient()->run($this, "show --pretty=format:\"<item><hash>%H</hash><short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents><author>%an</author><author_email>%ae</author_email><date>%at</date><commiter>%cn</commiter><commiter_email>%ce</commiter_email><commiter_date>%ct</commiter_date><message><![CDATA[%s]]></message><body><![CDATA[%b]]></body></item>\" $commitHash");
+        }
         $xmlEnd = strpos($logs, '</item>') + 7;
         $commitInfo = substr($logs, 0, $xmlEnd);
         $commitData = substr($logs, $xmlEnd);


### PR DESCRIPTION
The 1.8.4 Git update supports a [a number of different options](http://git-scm.com/docs/git-show) for the "git show" command. Among these include flags to ignore whitespace in diffs. This patch uses the whitespace flags if the user has v1.8.4 installed and falls back to the previous way of showing diffs if their Git installation is not up to that version.

This makes looking at diffs much easier if you constantly have developers committing whitespace changes!
