### PR TITLE
Using isset to avoid undefined variable error when there are no diffs.

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -406,8 +406,8 @@ class Repository
                 $lineNumOld++;
                 $lineNumNew++;
             }
-            
-            if ($diff) {
+
+            if (isset($diff)) {
                 $diff->addLine($log, $lineNumOld, $lineNumNew);
             }
         }
@@ -421,7 +421,7 @@ class Repository
 
     /**
      * Get the current HEAD.
-     * 
+     *
      * @param $default Optional branch to default to if in detached HEAD state.
      * If not passed, just grabs the first branch listed.
      * @return string the name of the HEAD branch, or a backup option if


### PR DESCRIPTION
This is related to #16.
