### PR TITLE
Escape git path using ProcessUtils::escapeArgument.

### DIFF
--- a/lib/Gitter/Client.php
+++ b/lib/Gitter/Client.php
@@ -13,6 +13,7 @@ namespace Gitter;
 
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\ProcessUtils;
 
 class Client
 {
@@ -66,7 +67,7 @@ class Client
             $command = '-c "color.ui"=false ' . $command;
         }
 
-        $process = new Process($this->getPath() . ' ' . $command, $repository->getPath());
+        $process = new Process(ProcessUtils::escapeArgument($this->getPath()) . ' ' . $command, $repository->getPath());
         $process->setTimeout(180);
         $process->run();
 
@@ -79,7 +80,7 @@ class Client
 
     public function getVersion()
     {
-        $process = new Process($this->getPath() . ' --version');
+        $process = new Process(ProcessUtils::escapeArgument($this->getPath()) . ' --version');
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
This is pretty much required if you want to run Gitter on Windows.

The other option is to use the [ProcessBuilder](http://api.symfony.com/2.6/Symfony/Component/Process/ProcessBuilder.html), but that would require rewriting pretty much all calls to `Client::run` to send over an array.
