### PR TITLE
use DIRECTORY_SEPARATOR constant when getting top level name

### DIFF
--- a/lib/Gitter/Client.php
+++ b/lib/Gitter/Client.php
@@ -97,7 +97,7 @@ class Client
      */
     protected function getPath()
     {
-        return $this->path;
+        return escapeshellarg($this->path);
     }
 
     /**

--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -219,8 +219,8 @@ class Repository
     {
         $name = rtrim($this->path, '/');
 
-        if (strstr($name, '/')) {
-            $name = substr($name, strrpos($name, '/') + 1);
+        if (strstr($name, DIRECTORY_SEPARATOR)) {
+            $name = substr($name, strrpos($name, DIRECTORY_SEPARATOR) + 1);
         }
 
         return trim($name);


### PR DESCRIPTION
This is needed for getting the name on Windows hosts