### PR TITLE
Fix part of https://github.com/klaussilveira/gitlist/issues/419; enforce...

### DIFF
--- a/lib/Gitter/Model/Tree.php
+++ b/lib/Gitter/Model/Tree.php
@@ -28,8 +28,8 @@ class Tree extends Object implements \RecursiveIterator
 
     public function parse()
     {
-        $data = $this->getRepository()->getClient()->run($this->getRepository(), 'ls-tree -l ' . $this->getHash());
-        $lines = explode("\n", $data);
+        $data = $this->getRepository()->getClient()->run($this->getRepository(), 'ls-tree -lz ' . $this->getHash());
+        $lines = explode("\0", $data);
         $files = array();
         $root = array();
 


### PR DESCRIPTION
... not to quote non ascii characters

It is not viable to rely on a particular server config. Instead it should be enough to
use the -z option so that the code works independently from any server configuration