### PR TITLE
fix for git 2.4.x

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -244,7 +244,9 @@ class Repository
         // Since we've stripped whitespace, the result "* (detached from "
         // and "* (no branch)" that is displayed in detached HEAD state
         // becomes "(detachedfrom" and "(nobranch)" respectively.
-        if ((strpos($branches[0], '(detachedfrom') === 0) || ($branches[0] === '(nobranch)')) {
+        if ((strpos($branches[0], '(detachedfrom') === 0)
+            || (strpos($branches[0], '(HEADdetachedat') === 0)
+            || ($branches[0] === '(nobranch)')) {
             $branches = array_slice($branches, 1);
         }
 
@@ -264,7 +266,9 @@ class Repository
 
         foreach ($branches as $branch) {
             if ($branch[0] === '*') {
-                if ((strpos($branch, '* (detached from ') === 0) || ($branch === '* (no branch)')) {
+                if ((strpos($branch, '* (detached from ') === 0)
+                    || (strpos($branch, '* (HEAD detached at ') === 0)
+                    || ($branch === '* (no branch)')) {
                     return NULL;
                 }
 

--- a/tests/Gitter/Tests/RepositoryTest.php
+++ b/tests/Gitter/Tests/RepositoryTest.php
@@ -176,13 +176,13 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $repository = $this->client->getRepository(self::$tmpdir . '/testrepo');
         $branch = $repository->getCurrentBranch();
-        $this->assertTrue($branch === 'master');
+        $this->assertEquals('master', $branch);
 
         $commits = $repository->getCommits();
         $hash = $commits[0]->getHash();
         $repository->checkout($hash);
         $new_branch = $repository->getCurrentBranch();
-        $this->assertTrue($new_branch === NULL);
+        $this->assertNull($new_branch);
 
         $repository->checkout($branch);
     }
@@ -195,7 +195,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $hash = $commits[0]->getHash();
         $repository->checkout($hash);
         $branches = $repository->getBranches();
-        $this->assertTrue(count($branches) === 3);
+        $this->assertEquals(3, count($branches), print_r($branches, true));
 
         $branch = $repository->getHead('develop');
         $repository->checkout($current_branch);


### PR DESCRIPTION
For you information we are running CI in Fedora.
See 
- http://blog.famillecollet.com/post/2014/08/12/Koschei-continuous-integration-of-PHP-stack-in-Fedora
- http://koschei.cloud.fedoraproject.org/package/php-gitter

This library is broken since git was updated to 2.4

This fix adapt code for new git output and improve a bit test for better information.

Would be nice to consider dropping the stopOnFailure="true" in phpunit.xml
