### PR TITLE
Improve performance

### DIFF
--- a/lib/Gitter/Client.php
+++ b/lib/Gitter/Client.php
@@ -79,6 +79,12 @@ class Client
 
     public function getVersion()
     {
+        static $version;
+
+        if (null !== $version) {
+            return $version;
+        }
+
         $process = new Process($this->getPath() . ' --version');
         $process->run();
 
@@ -86,8 +92,8 @@ class Client
             throw new \RuntimeException($process->getErrorOutput());
         }
 
-        $version = substr($process->getOutput(), 12);
-        return trim($version);
+        $version = trim(substr($process->getOutput(), 12));
+        return $version;
     }
 
     /**

--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -233,6 +233,12 @@ class Repository
      */
     public function getBranches()
     {
+        static $branches;
+
+        if (null !== $branches) {
+            return $branches;
+        }
+
         $branches = $this->getClient()->run($this, "branch");
         $branches = explode("\n", $branches);
         $branches = array_filter(preg_replace('/[\*\s]/', '', $branches));
@@ -322,6 +328,12 @@ class Repository
      */
     public function getTags()
     {
+        static $tags = false;
+
+        if (false !== $tags) {
+            return $tags;
+        }
+
         $tags = $this->getClient()->run($this, "tag");
         $tags = explode("\n", $tags);
         array_pop($tags);


### PR DESCRIPTION
Improved the performance of several method calls by avoiding repetitive and identical Process calls. As the returned value is always going to be the same anyway, caching the result the first time the method is called dramatically improves the performance of the code.

More information:
https://blackfire.io/docs/24-days/04-first-profile
https://blackfire.io/docs/24-days/05-performance-optimizations-validation
