### PR TITLE
getLastTag method added into Repository class, Issue #54

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -345,6 +345,15 @@ class Repository
         return $cache[$this->path] = $tags;
     }
 
+    public function getLastTag()
+    {
+        $command = "describe --abbrev=0 --tags";
+
+        $tag = $this->getClient()->run($this, $command);
+
+        return trim($tag);
+    }
+
     /**
      * Show the amount of commits on the repository
      *

--- a/tests/Gitter/Tests/RepositoryTest.php
+++ b/tests/Gitter/Tests/RepositoryTest.php
@@ -168,8 +168,10 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $repository->createTag('1.0.0');
         $repository->createTag('1.0.1', 'annotated tag');
         $tags = $repository->getTags();
+        $last= $repository->getLastTag();
         $this->assertContains('1.0.0', $tags);
         $this->assertContains('1.0.1', $tags);
+        $this->assertEquals('1.0.1', $last);
     }
 
     public function testIsGettingCurrentBranch()

--- a/tests/Gitter/Tests/RepositoryTest.php
+++ b/tests/Gitter/Tests/RepositoryTest.php
@@ -168,7 +168,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $repository->createTag('1.0.0');
         $repository->createTag('1.0.1', 'annotated tag');
         $tags = $repository->getTags();
-        $last= $repository->getLastTag();
+        $last = $repository->getLastTag();
         $this->assertContains('1.0.0', $tags);
         $this->assertContains('1.0.1', $tags);
         $this->assertEquals('1.0.1', $last);


### PR DESCRIPTION
This soft changes can help to get the last Tag, instead of create an algorithm to parse the last tag from all of them.
