### PR TITLE
rename Object to Thing for PHP 7.2

### DIFF
--- a/lib/Gitter/Model/Blob.php
+++ b/lib/Gitter/Model/Blob.php
@@ -13,7 +13,7 @@ namespace Gitter\Model;
 
 use Gitter\Repository;
 
-class Blob extends Object
+class Blob extends Thing
 {
     protected $mode;
     protected $name;

--- a/lib/Gitter/Model/Commit/Commit.php
+++ b/lib/Gitter/Model/Commit/Commit.php
@@ -11,10 +11,10 @@
 
 namespace Gitter\Model\Commit;
 
-use Gitter\Model\Object;
+use Gitter\Model\Thing;
 use Gitter\Util\DateTime;
 
-class Commit extends Object
+class Commit extends Thing
 {
     protected $shortHash;
     protected $treeHash;

--- a/lib/Gitter/Model/Tag.php
+++ b/lib/Gitter/Model/Tag.php
@@ -11,7 +11,7 @@
 
 namespace Gitter\Model;
 
-class Tag extends Object
+class Tag extends Thing
 {
     protected $name;
 

--- a/lib/Gitter/Model/Thing.php
+++ b/lib/Gitter/Model/Thing.php
@@ -11,7 +11,7 @@
 
 namespace Gitter\Model;
 
-class Object extends AbstractModel
+class Thing extends AbstractModel
 {
     protected $hash;
 

--- a/lib/Gitter/Model/Tree.php
+++ b/lib/Gitter/Model/Tree.php
@@ -13,7 +13,7 @@ namespace Gitter\Model;
 
 use Gitter\Repository;
 
-class Tree extends Object implements \RecursiveIterator
+class Tree extends Thing implements \RecursiveIterator
 {
     protected $mode;
     protected $name;


### PR DESCRIPTION
From Fedora QA
https://apps.fedoraproject.org/koschei/package/php-gitter?collection=f28

```
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.2.0RC6
Configuration: /builddir/build/BUILD/gitter-6eff42830c336ee9b8b8b9d2f69b62bd9bcbaf3b/phpunit.xml
.......PHP Fatal error:  Cannot use Gitter\Model\Object as Object because 'Object' is a special class name in /builddir/build/BUILDROOT/php-gitter-0.3.0-9.fc28.noarch/usr/share/php/Gitter/Model/Commit/Commit.php on line 14
```
Object is now a reserved Keyword.
