### PR TITLE
Update Repository.php

### DIFF
--- a/lib/Gitter/Repository.php
+++ b/lib/Gitter/Repository.php
@@ -420,7 +420,7 @@ class Repository
         $commit->importData($data[0]);
 
         if (empty($logs[1])) {
-            $logs = explode("\n", $this->getClient()->run($this, 'diff ' . $commitHash . '~1..' . $commitHash));
+            $logs = explode("\n", $this->getClient()->run($this, 'diff ' . $commitHash . '..' . $commitHash));
         }
 
         $commit->setDiffs($this->readDiffLogs($logs));


### PR DESCRIPTION
$commitHash . '**~1**..' . $commitHash does invalid git command:
/usr/bin/git diff dcfb86e~1..dcfb86e
GitConnector: fatal: ambiguous argument 'dcfb86e**~1**..dcfb86e': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git [...] -- [...]'