### PR TITLE
fix: replace hex chars which break xml

### DIFF
--- a/lib/Gitter/PrettyFormat.php
+++ b/lib/Gitter/PrettyFormat.php
@@ -13,13 +13,25 @@ namespace Gitter;
 
 class PrettyFormat
 {
+    public function escapeXml($output)
+    {
+      return preg_replace('/[\x00-\x1f]/', '?', $output);
+    }
+
     public function parse($output)
     {
         if (empty($output)) {
             throw new \RuntimeException('No data available');
         }
 
-        $data = $this->iteratorToArray(new \SimpleXmlIterator("<data>$output</data>"));
+        try {
+          $xml = new \SimpleXmlIterator("<data>$output</data>");
+        } catch (\Exception $e) {
+          $output = $this->escapeXml($output);
+          $xml = new \SimpleXmlIterator("<data>$output</data>");
+        }
+
+        $data = $this->iteratorToArray($xml);
 
         return $data['item'];
     }

--- a/tests/Gitter/Tests/PrettyFormatTest.php
+++ b/tests/Gitter/Tests/PrettyFormatTest.php
@@ -36,6 +36,10 @@ class PrettyFormatTest extends TestCase
                 '<item><tag><inner_tag>value</inner_tag></tag></item>',
                 array(array('tag' => array(array('inner_tag' => 'value')))),
             ),
+            array(
+                "<item><tag>value\x1B</tag><tag2>value2</tag2></item>",
+                array(array('tag' => 'value?', 'tag2' => 'value2')),
+            ),
         );
     }
 


### PR DESCRIPTION
Thanks for your work. Was using gitlist and somehow the char `\x1b` got into the subject of my multi-line commit subject/message which broke parsing of the xml. This should fix that by replace all faulty chars with a `?`

Used the try/catch so the preg-replace is not introducing a lot of overhead in situations where the xml is just valid.

(char range taken from here: https://stackoverflow.com/questions/10133015/replace-this-hex-chars-from-string-in-php)