### PR TITLE
Fix ls-tree parsing bug and use dist: trusty for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
   - 5.4

--- a/lib/Gitter/Model/Tree.php
+++ b/lib/Gitter/Model/Tree.php
@@ -39,7 +39,10 @@ class Tree extends GitObject implements \RecursiveIterator
                 continue;
             }
 
-            $files[] = preg_split("/[\s]+/", $line, 5);
+            $tabSplit = preg_split("/[\t]+/", $line, 2);
+            $file = preg_split("/[\s]+/", $tabSplit[0], 4);
+            $file[] = $tabSplit[1];
+            $files[] = $file;
         }
 
         foreach ($files as $file) {


### PR DESCRIPTION
Output format of `git ls-tree` with the `-l` option is

```
<mode> SP <type> SP <object> SP <object size> TAB <file>
```

Currently, if a filename begins with whitespace, Gitter will strip that whitespace. This PR fixes the splitting logic to consider the `TAB` as well and return the correct filename.