### PR TITLE
Symfony 4.2+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=5.3",
-        "symfony/process": "^2.8"
+        "symfony/process": "^5.0 || ^6.0"
     },
     "require-dev": {
-        "symfony/filesystem": "^2.8",
+        "symfony/filesystem": "^5.0 || ^6.0",
         "phpunit/phpunit": "~8",
         "mockery/mockery": "0.9.1"
     },

--- a/lib/Gitter/Client.php
+++ b/lib/Gitter/Client.php
@@ -68,7 +68,7 @@ class Client
             $command = '-c "color.ui"=false ' . $command;
         }
 
-        $process = new Process($this->getPath() . ' ' . $command, $repository->getPath());
+        $process = Process::fromShellCommandline($this->getPath() . ' ' . $command, $repository->getPath());
         $process->setTimeout(180);
         $process->run();
 
@@ -87,7 +87,7 @@ class Client
             return $version;
         }
 
-        $process = new Process($this->getPath() . ' --version');
+        $process = Process::fromShellCommandline($this->getPath() . ' --version');
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
Probably it could use `method_exists()` and stay compatible with 2.8 .. 6.x


https://github.com/symfony/symfony/commit/8895bc1b5bab9af56fbc4458337f83046347bab5

Closes https://github.com/klaussilveira/gitter/issues/70